### PR TITLE
[FIX] website: remove only the "history" carousel listeners at destroy

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -466,10 +466,10 @@ registry.slider = publicWidget.Widget.extend({
         $(window).on('resize.slider', debounce(() => this._computeHeights(), 250));
         if (this.editableMode) {
             // Prevent carousel slide to be an history step.
-            this.$el.on("slide.bs.carousel", () => {
+            this.$el.on("slide.bs.carousel.slider", () => {
                 this.options.wysiwyg.odooEditor.observerUnactive();
             });
-            this.$el.on("slid.bs.carousel", () => {
+            this.$el.on("slid.bs.carousel.slider", () => {
                 this.options.wysiwyg.odooEditor.observerActive();
             });
         }
@@ -489,7 +489,7 @@ registry.slider = publicWidget.Widget.extend({
                 $(el).css("min-height", "");
             });
         $(window).off('.slider');
-        this.$target.off('.carousel');
+        this.$el.off('.slider');
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
In order to not add steps in the history when changing the slides of a carousel, commit [1] added listeners that would deactivate the observer when sliding and reactivate it when the slide is over, in the `slider` public widget. These listeners are then removed at destroy.

However, the way they are removed breaks some of the carousel behaviors:
- Drop a "Carousel" snippet.
- Change any "Carousel" option (so not a "Slide" one). For example, set the "Height" to 50% or add a conditional visibility.
- Slide the carousel (with any arrow). => The slide number did not update correctly.
- Remove a slide with the "-" button. => The slide was not removed.

It happens because, when this widget is destroyed, it removes all the `.carousel` listeners, which means that it also removes the listeners added at the `Carousel` options start. And since the widget is destroyed and restarted every time an option is changed, but the "Carousel" options are started only once at the beginning, the removed listeners are never added back (until the next start of the options).

This commit adds an id to the events managing the sliding history, to make them more specific, in order to only remove these ones when the widget is destroyed.

[1]: https://github.com/odoo/odoo/commit/14bc1a9bd1ebdec3b73e268450267320b79d01cd

opw-3675019

closes odoo/odoo#153578

X-original-commit: 041935aff660ae5df1220e3d844d2a2cbcf4ee5c

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
